### PR TITLE
Fix auth token handling in Flet client

### DIFF
--- a/habio_python/src/core/session.py
+++ b/habio_python/src/core/session.py
@@ -21,13 +21,16 @@ def _write_session(data: dict):
 
 def set_token(token: str):
     data = _read_session()
-    data["access_token"] = "bearer " +token
+    data["access_token"] = token
     _write_session(data)
 
 
 def get_token() -> str | None:
     data = _read_session()
-    return data.get("access_token")
+    token = data.get("access_token")
+    if isinstance(token, str) and token.lower().startswith("bearer "):
+        return token.split(" ", 1)[1]
+    return token
 
 
 def clear_token():

--- a/habio_python/src/features/auth/auth_controller.py
+++ b/habio_python/src/features/auth/auth_controller.py
@@ -2,7 +2,7 @@ from src.models.user import User
 from src.models.room import Room
 from src.core.session import set_token, get_token, clear_token
 from src.features.auth.auth_repository import login as api_login, register as api_register, me as api_me
-from src.services.http_client import APIError
+from src.services.http_client import APIError, client
 
 class AuthController:
     current_user_id = None
@@ -15,6 +15,7 @@ class AuthController:
             if not token:
                 return False, "Login failed"
             set_token(token)
+            client.set_token(token)
             # Fetch user
             user_data = api_me()
             # Upsert local user
@@ -37,21 +38,7 @@ class AuthController:
             if not token:
                 return False, "Registration failed"
             set_token(token)
-            # Fetch user
-            user_data = api_me()
-            user, created = User.get_or_create(username=user_data.get("username"), defaults={
-                "email": user_data.get("email"),
-                "password_hash": "",
-            })
-            # Create default room locally if not exists
-            if not Room.select().where((Room.user == user) & (Room.name == "My Room")).exists():
-                Room.create(user=user, name="My Room")
-            cls.current_user_id = user.id
-            resp = api_register(username, email, password)
-            token = resp.get("access_token")
-            if not token:
-                return False, "Registration failed"
-            set_token(token)
+            client.set_token(token)
             # Fetch user
             user_data = api_me()
             user, created = User.get_or_create(username=user_data.get("username"), defaults={
@@ -71,12 +58,7 @@ class AuthController:
     @classmethod
     def logout(cls):
         clear_token()
-        cls.current_user_id = None
-        return True
-
-    @classmethod
-    def logout(cls):
-        clear_token()
+        client.set_token(None)
         cls.current_user_id = None
         return True
 
@@ -84,19 +66,6 @@ class AuthController:
     def get_current_user(cls):
         if cls.current_user_id:
             return User.get_by_id(cls.current_user_id)
-        # Try from token
-        token = get_token()
-        if token:
-            try:
-                user_data = api_me()
-                user, created = User.get_or_create(username=user_data.get("username"), defaults={
-                    "email": user_data.get("email"),
-                    "password_hash": "",
-                })
-                cls.current_user_id = user.id
-                return user
-            except Exception:
-                return None
         # Try from token
         token = get_token()
         if token:

--- a/habio_python/src/services/http_client.py
+++ b/habio_python/src/services/http_client.py
@@ -18,7 +18,7 @@ class HttpClient:
         self.base_url = base_url or BASE_URL
         self.token: Optional[str] = None
 
-    def set_token(self, token: str):
+    def set_token(self, token: Optional[str]):
         self.token = token
 
     def _headers(self):


### PR DESCRIPTION
### Motivation
- Fix a bug where `/auth/me` returned 401 because the client sent an incorrect `Authorization` header built from a legacy `bearer `-prefixed value. 
- Ensure the app stores raw JWTs and normalizes any legacy prefixed tokens so HTTP requests use the correct token. 
- Keep local auth state and the global `HttpClient` token synchronized on login, register and logout to avoid stale/missing headers.

### Description
- Normalize session storage in `src/core/session.py` to store the raw token via `set_token` and to strip any legacy `"bearer "` prefix in `get_token`.
- Update `src/services/http_client.py` to accept `Optional[str]` in `HttpClient.set_token` so `None` can be cleared safely and the client sends `Authorization: Bearer <token>` only when present.
- Synchronize the global HTTP client token in `src/features/auth/auth_controller.py` by calling `client.set_token(token)` after login/register and `client.set_token(None)` on logout.
- Clean up duplicated/incorrect logic in `register`/`get_current_user` in `auth_controller.py` (removed duplicate registration calls and redundant token checks).

### Testing
- No automated tests were executed as part of this change (no `pytest`/CI run performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678e7e2bc08329a9995a99033efc4c)